### PR TITLE
Add config handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 node_modules/
 # misc
 **/.DS_Store
+# JetBrains WebStorm (I use this IDE)
+.idea
 # environment variables
 **/*.env*
 # log
 log.csv
+# data
+json/

--- a/common/ConfigHandler.mjs
+++ b/common/ConfigHandler.mjs
@@ -1,0 +1,56 @@
+import fs from "fs";
+import path from "path";
+import { mainDir } from "./Utils.mjs";
+
+const defaultConfig = {
+    port: 3000,
+}
+
+const configDir = path.join(mainDir, "json");
+const configFile = path.join(configDir, "config.json");
+
+/**
+ * Reads the config file.
+ * @return {any}
+ * @throws {Error} Will throw an error if the config file was not initialized.
+ */
+const read = () => {
+    if (!fs.existsSync(configFile)) {
+        throw new Error("Config was not initialized");
+    }
+    return JSON.parse(fs.readFileSync(configFile, "utf8"));
+}
+
+/**
+ * Writes all config data to config.json file with 4 space indentation.
+ * @param config {any} The config to write.
+ * @internal This is for use in this module only.
+ */
+const write = (config) => {
+    fs.writeFileSync(configFile, JSON.stringify(config, null, 4), "utf8");
+}
+
+/**
+ * Set a key to a value in the config file.
+ * @param key {string} The key to set.
+ * @param value {any} The value to set.
+ */
+const set = (key, value) => {
+    const config = read();
+    config[key] = value;
+    write(config);
+}
+
+/**
+ * Initialize the config file.
+ * @throws {Error} Will throw an error if the config directory was not created.
+ */
+const init = () => {
+    write(defaultConfig);
+}
+
+export default {
+    get: read,
+    set: set,
+    init: init,
+}

--- a/common/Utils.mjs
+++ b/common/Utils.mjs
@@ -1,0 +1,12 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url); // Gets the filename and dirname of the current module.
+const __dirname = path.dirname(__filename); // Reduces down to just the directory name.
+
+/**
+ * The main directory of the application.
+ * @type {string} The main directory of the application.
+ */
+// This takes from the
+export const mainDir = path.join(__dirname, "..");


### PR DESCRIPTION
### Description
This PR adds the config handling that will be used by both the CLI command and the site if we decide to add a page for config handling.

It has 3 exposed functions, get, set, and init. 
- get will be used for retrieve the json object of the file, this can then be used in whatever places it required.
- set will take a key and value and add that to the object and write that to the system.
- init will initialize a config.json with the default config object stored at the top of the module, this will also be used for resetting of the config.

Along with the ConfigHandler module I have added a generic Utils module which will contain helper methods for things, currently it contains a helper to get the main directory of the project which has been used by the ConfigHandler and will need to be used by the token handling.

---

In addition to the code I have also added the directory where tokens and configs will be stored to the gitignore along with the configuration folder for the IDE I use which is webstorm.