### PR TITLE
Add common token handling

### DIFF
--- a/common/TokenHandler.mjs
+++ b/common/TokenHandler.mjs
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path from "path";
+import { mainDir, nowPlusDays } from "./Utils.mjs";
+import { crc32 } from "crc";
+import { format, isFuture } from "date-fns";
+
+const DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+const EXPIRY_IN_DAYS = 3;
+
+const tokenDir = path.join(mainDir, "json");
+const tokenFile = path.join(tokenDir, "tokens.json");
+
+/**
+ * @typedef {Object} TokenEntry
+ * @property {string} created
+ * @property {string} username
+ * @property {string} [email] - Optional, Mutable
+ * @property {string} [phone] - Optional, Mutable
+ * @property {string} token
+ * @property {string} expires - Mutable
+ * @property {boolean} confirmed - Mutable
+ */
+
+/**
+ * Reads all tokens/users from disk.
+ * @return {TokenEntry[]}
+ */
+const read = () => {
+    if (!fs.existsSync(tokenFile)) {
+        return [];
+    }
+    const entries = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+    //Filter out expired tokens.
+    const filteredEntries = entries.filter(entry => isFuture(entry.expires));
+    // If tokens were filtered, write the new list to disk.
+    if (entries.length !== filteredEntries.length) {
+        write(filteredEntries);
+    }
+    return filteredEntries;
+}
+
+/**
+ * Writes all tokens/users to disk with 4 space indentation.
+ * @param entries {TokenEntry[]} The tokens to write.
+ * @internal This is for use in this module only.
+ */
+const write = (entries) => {
+    fs.writeFileSync(tokenFile, JSON.stringify(entries, null, 4), "utf8");
+}
+
+/**
+ * Adds and returns a new user and token for a given username.
+ * @param username {string} The username to create a token for.
+ * @return {string} The token for the given username.
+ */
+const create = (username) => {
+    const token = crc32(username).toString(16);
+    const in3days = nowPlusDays(EXPIRY_IN_DAYS);
+
+    if (!update(token, {expires: format(in3days, DATE_FORMAT)})) {
+        const entries = read();
+        entries.push({
+            created: format(new Date(), DATE_FORMAT),
+            username: username,
+            token: token,
+            expires: format(in3days, DATE_FORMAT),
+            confirmed: false,
+        });
+        write(entries);
+    }
+    return token;
+}
+
+/**
+ * @param token {string}
+ * @param data {any | TokenEntry}
+ * @return {boolean} True if the token was found and updated, false otherwise.
+ */
+const update = (token, data) => {
+    const entries = read();
+    const entryIndex = entries.findIndex(t => t.token === token);
+    if (entryIndex !== -1) {
+        // Merges the existing token data with the new data.
+        // This means that the new data will overwrite the old data, but the old data will remain if not overwritten.
+        entries[entryIndex] = {
+            ...entries[entryIndex],
+            ...data,
+        }
+        write(entries);
+        return true;
+    }
+    return false;
+}
+
+export default {
+    get: read,
+    create: create,
+    update: update,
+}

--- a/common/Utils.mjs
+++ b/common/Utils.mjs
@@ -8,5 +8,16 @@ const __dirname = path.dirname(__filename); // Reduces down to just the director
  * The main directory of the application.
  * @type {string} The main directory of the application.
  */
-// This takes from the
+// This takes from the current module's directory and goes up one level.
 export const mainDir = path.join(__dirname, "..");
+
+/**
+ * Returns the current date plus the given days.
+ * @param days {number} The amount of days to add to the current date.
+ * @return {Date} The current date plus the given days.
+ */
+export const nowPlusDays = (days) => {
+    const date = new Date();
+    date.setDate(date.getDate() + days);
+    return date;
+}


### PR DESCRIPTION
### Description

This adds the common token handling which is required in the sprint document as specified that the token handling needs to be used between both the web app and cli. Also uses CRC as also required by the sprint document.

As it currently stands this handling provides away to read and create a token, with a helper method to update a token. And only an internal function for writing directly to the tokens as this should not be done outside of updating a token.

Additionally this also adds a helper function in utils for creating a date plus x amount of days.